### PR TITLE
Add countdown and penalty display timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Inspection Timer</title>
+<style>
+#timer-display {
+  font-size: 2em;
+}
+.red {
+  color: red;
+}
+</style>
+</head>
+<body>
+<div id="timer-display">15</div>
+<button onclick="startInspection()">Start Inspection</button>
+<button onclick="startTimer()">Start Timer</button>
+<button onclick="stopTimer()">Stop Timer</button>
+<script src="timer.js"></script>
+</body>
+</html>

--- a/timer.js
+++ b/timer.js
@@ -1,0 +1,53 @@
+let timerDisplay = document.getElementById('timer-display');
+let inspectionInterval = null;
+let inspectionRemaining = 15;
+let timerStart = null;
+let timerInterval = null;
+let penalty = '';
+
+function startInspection() {
+  clearInterval(inspectionInterval);
+  inspectionRemaining = 15;
+  timerDisplay.classList.remove('red');
+  timerDisplay.textContent = inspectionRemaining;
+  inspectionInterval = setInterval(() => {
+    inspectionRemaining--;
+    if (inspectionRemaining >= -2) {
+      if (inspectionRemaining === 0) {
+        timerDisplay.textContent = 'Stop';
+        timerDisplay.classList.add('red');
+      } else {
+        timerDisplay.textContent = inspectionRemaining;
+      }
+    } else {
+      clearInterval(inspectionInterval);
+    }
+  }, 1000);
+}
+
+function startTimer() {
+  clearInterval(timerInterval);
+  timerStart = performance.now();
+  timerDisplay.classList.remove('red');
+  timerInterval = setInterval(() => {
+    const elapsed = (performance.now() - timerStart) / 1000;
+    timerDisplay.textContent = elapsed.toFixed(3);
+  }, 10);
+}
+
+function stopTimer() {
+  clearInterval(timerInterval);
+  if (!timerStart) return;
+  const elapsed = (performance.now() - timerStart) / 1000;
+  const formatted = elapsed.toFixed(3);
+  if (penalty === '+2') {
+    const finalTime = (elapsed + 2).toFixed(3);
+    timerDisplay.textContent = `${formatted}+2=${finalTime}`;
+  } else {
+    timerDisplay.textContent = formatted;
+    if (penalty === 'DNF') {
+      timerDisplay.textContent += ' DNF';
+    }
+  }
+  timerStart = null;
+}


### PR DESCRIPTION
## Summary
- add a simple HTML/JS demo for an inspection timer
- show countdown from 15 to 0 and continue to -2
- display **Stop** in red at 0
- show original time and final time if a +2 penalty is given
- append `DNF` to the time when applicable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d91a12a48322b8cabb9697e6839a