### PR TITLE
Implement broader WCA scrambles

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,9 +22,17 @@
 <div style="margin-top:20px;">
 <label><input type="checkbox" id="hideTime"> 隱藏計時</label>
 <select id="scrambleType">
-<option value="3">3x3</option>
-<option value="2">2x2</option>
-<option value="4">4x4</option>
+  <option value="3">3x3</option>
+  <option value="2">2x2</option>
+  <option value="4">4x4</option>
+  <option value="5">5x5</option>
+  <option value="6">6x6</option>
+  <option value="7">7x7</option>
+  <option value="pyra">Pyraminx</option>
+  <option value="mega">Megaminx</option>
+  <option value="skewb">Skewb</option>
+  <option value="sq1">Square-1</option>
+  <option value="clock">Clock</option>
 </select>
 <label><input type="checkbox" id="oneHour"> 1小時模式</label>
 </div>
@@ -44,7 +52,7 @@ let ready = false;
 let inspectionStart = 0;
 let inspectionInterval = null;
 let penalty = '';
-let scrambleType = 3;
+let scrambleType = '3';
 
 function pad(n, width){
   let s = n+''; if(s.length < width) s = '0'.repeat(width - s.length)+s; return s;
@@ -59,23 +67,108 @@ function formatTime(ms){
   return `${pad(m,2)}:${pad(s,2)}.${pad(cs,3)}`;
 }
 
-function generateScramble(){
-  scrambleType = parseInt(scrambleTypeSelect.value,10);
-  const moves = ['U','D','L','R','F','B'];
+function scrambleNxN(n){
+  const base = ['U','D','L','R','F','B'];
+  let moves = base.slice();
+  if(n >= 4){
+    moves = moves.concat(['Uw','Dw','Lw','Rw','Fw','Bw']);
+  }
   const mods = ['', "'", '2'];
-  let len = 20;
-  if(scrambleType===2) len = 11;
-  if(scrambleType===4) len = 40;
-  let lastMove = '';
+  const lengthMap = {2:11,3:20,4:40,5:60,6:80,7:100};
+  const len = lengthMap[n] || 20;
+  let lastAxis = '';
   const out = [];
   for(let i=0;i<len;i++){
-    let move = moves[Math.floor(Math.random()*moves.length)];
-    while(move[0]===lastMove[0]) move = moves[Math.floor(Math.random()*moves.length)];
-    lastMove = move;
-    move += mods[Math.floor(Math.random()*mods.length)];
-    out.push(move);
+    let m = moves[Math.floor(Math.random()*moves.length)];
+    while(m[0]===lastAxis) m = moves[Math.floor(Math.random()*moves.length)];
+    lastAxis = m[0];
+    m += mods[Math.floor(Math.random()*mods.length)];
+    out.push(m);
   }
-  scrambleDisplay.textContent = out.join(' ');
+  return out.join(' ');
+}
+
+function scramblePyraminx(){
+  const moves = ['U','L','R','B'];
+  const mods = ['', "'"];
+  const len = 9;
+  let last = '';
+  const out = [];
+  for(let i=0;i<len;i++){
+    let m = moves[Math.floor(Math.random()*moves.length)];
+    while(m===last) m = moves[Math.floor(Math.random()*moves.length)];
+    last = m;
+    m += mods[Math.floor(Math.random()*mods.length)];
+    out.push(m);
+  }
+  ['u','l','r','b'].forEach(t=>{if(Math.random()<0.5) out.push(t+mods[Math.floor(Math.random()*mods.length)]);});
+  return out.join(' ');
+}
+
+function scrambleSkewb(){
+  const moves = ['U','L','R','B'];
+  const mods = ['', "'"];
+  const len = 10;
+  let last = '';
+  const out = [];
+  for(let i=0;i<len;i++){
+    let m = moves[Math.floor(Math.random()*moves.length)];
+    while(m===last) m = moves[Math.floor(Math.random()*moves.length)];
+    last = m;
+    m += mods[Math.floor(Math.random()*mods.length)];
+    out.push(m);
+  }
+  return out.join(' ');
+}
+
+function scrambleMegaminx(){
+  const moves = ['R++','R--','D++','D--'];
+  const len = 70;
+  const out = [];
+  for(let i=0;i<len;i++) out.push(moves[Math.floor(Math.random()*moves.length)]);
+  return out.join(' ');
+}
+
+function scrambleSq1(){
+  const len = 15;
+  const out = [];
+  for(let i=0;i<len;i++){
+    const a = Math.floor(Math.random()*12)-5;
+    const b = Math.floor(Math.random()*12)-5;
+    out.push(`(${a},${b})`);
+    if(i!==len-1) out.push('/');
+  }
+  return out.join(' ');
+}
+
+function scrambleClock(){
+  const faces = ['UR','DR','DL','UL','U','R','L','D','ALL'];
+  const turns = [-5,-4,-3,-2,-1,1,2,3,4,5];
+  const out = [];
+  for(let i=0;i<12;i++){
+    const f = faces[Math.floor(Math.random()*faces.length)];
+    const t = turns[Math.floor(Math.random()*turns.length)];
+    out.push(f+t);
+  }
+  out.push('y2');
+  return out.join(' ');
+}
+
+function generateScramble(){
+  scrambleType = scrambleTypeSelect.value;
+  if(['2','3','4','5','6','7'].includes(scrambleType)){
+    scrambleDisplay.textContent = scrambleNxN(parseInt(scrambleType,10));
+  } else if(scrambleType==='pyra'){
+    scrambleDisplay.textContent = scramblePyraminx();
+  } else if(scrambleType==='mega'){
+    scrambleDisplay.textContent = scrambleMegaminx();
+  } else if(scrambleType==='skewb'){
+    scrambleDisplay.textContent = scrambleSkewb();
+  } else if(scrambleType==='sq1'){
+    scrambleDisplay.textContent = scrambleSq1();
+  } else if(scrambleType==='clock'){
+    scrambleDisplay.textContent = scrambleClock();
+  }
 }
 
 generateScramble();


### PR DESCRIPTION
## Summary
- expand puzzle selector with more WCA puzzles
- implement new scramble generator with wide turns and puzzle-specific logic

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e15297188322bd87cff74a3a895a