### PR TITLE
Display hold square with CSS color

### DIFF
--- a/index.php
+++ b/index.php
@@ -132,11 +132,11 @@ document.body.addEventListener('keydown', e => {
     if(!holding && !timerInterval){
       holding = true;
       ready = false;
-      statusDisplay.textContent = '\u9ec3';
+      statusDisplay.textContent = '\u25A0';
       statusDisplay.className = 'yellow';
       holdTimeout = setTimeout(() => {
         ready = true;
-        statusDisplay.textContent = '\u7da0';
+        statusDisplay.textContent = '\u25A0';
         statusDisplay.className = 'green';
       }, 800);
     } else if(timerInterval){


### PR DESCRIPTION
## Summary
- show a colored square instead of Chinese characters when holding the timer key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f2a948f0832287d515c7044355ee