### PR TITLE
Use cubejs for scrambles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,11 @@ This file records a summary of repository changes and a short description of eac
 
 ### PR: Document timer usage
 - Replaced the placeholder readme with a short overview of `index.php`, local server instructions, and note that all code lives in one file.
+
+### PR: Use cubejs scrambles
+- Loaded cubejs from a CDN in `index.php`.
+- Implemented `generateScramble()` using cubejs for 2x2, 3x3, and 4x4 events.
+
+### PR: Refine cubejs usage
+- Removed the unused `scrambleType` variable.
+- Documented cubejs-powered scrambles in the readme.

--- a/index.php
+++ b/index.php
@@ -37,6 +37,7 @@
 </select>
 <label><input type="checkbox" id="oneHour"> 1小時模式</label>
 </div>
+<script src="https://unpkg.com/cubejs/lib/cube.min.js"></script>
 <script>
 const timerDisplay = document.getElementById('timer');
 const statusDisplay = document.getElementById('status');
@@ -54,7 +55,6 @@ let inspectionStart = 0;
 let inspectionInterval = null;
 let penalty = '';
 
-let scrambleType = '3';
 
 
 function pad(n, width){
@@ -70,6 +70,14 @@ function formatTime(ms){
   return `${pad(m,2)}:${pad(s,2)}.${pad(cs,3)}`;
 }
 
+function generateScramble(){
+  const map = { '2': '222', '3': '333', '4': '444' };
+  const puzzle = map[scrambleTypeSelect.value];
+  if(puzzle){
+    scrambleDisplay.textContent = cubejs.scramble(puzzle);
+  } else {
+    scrambleDisplay.textContent = '';
+  }
 }
 
 generateScramble();

--- a/readme
+++ b/readme
@@ -1,6 +1,6 @@
 # Cubing Timer Overview
 
-`index.php` provides a simple timer for puzzle solving with built-in scramble generation. Load it through any PHP-enabled server to track your solves.
+`index.php` provides a simple timer for puzzle solving with built-in scramble generation. Scrambles for 2x2–4x4 are powered by the cubejs library loaded from a CDN. Load the file through any PHP-enabled server to track your solves.
 
 Run locally with:
 


### PR DESCRIPTION
## Summary
- load cubejs from unpkg
- implement `generateScramble()` using cubejs for 2x2, 3x3 and 4x4
- document the update in AGENTS summary
- remove unused `scrambleType` var and note cubejs in readme

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ea9cfdac8322a2f2a00fe672c8dc