### PR TITLE
Support additional scrambles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,7 @@ This file records a summary of repository changes and a short description of eac
 ### PR: Refactor timer script
 - Extracted all timer logic into `timer.js` as an ES module.
 - Imported `generateScramble()` and `startInspection()` in `index.php` to initialize the page.
+
+### PR: Support more scrambles
+- Extended `generateScramble()` in `timer.js` to cover 5x5–7x7 and non-cube puzzles.
+- Updated the readme to note cubejs provides scrambles for common WCA events.

--- a/readme
+++ b/readme
@@ -1,6 +1,6 @@
 # Cubing Timer Overview
 
-`index.php` provides a simple timer for puzzle solving with built-in scramble generation. Scrambles for 2x2–4x4 are powered by the cubejs library loaded from a CDN. Load the file through any PHP-enabled server to track your solves.
+`index.php` provides a simple timer for puzzle solving with built-in scramble generation. Scrambles for common WCA events are powered by the cubejs library loaded from a CDN. Load the file through any PHP-enabled server to track your solves.
 
 Run locally with:
 

--- a/timer.js
+++ b/timer.js
@@ -34,13 +34,32 @@ export function formatTime(ms) {
 
 export function generateScramble() {
   scrambleType = scrambleTypeSelect.value;
-  const map = { '2': '222', '3': '333', '4': '444' };
+  const map = {
+    '2': '222',
+    '3': '333',
+    '4': '444',
+    '5': '555',
+    '6': '666',
+    '7': '777',
+    'pyra': 'pyram',
+    'mega': 'minx',
+    'skewb': 'skewb',
+    'sq1': 'sq1',
+    'clock': 'clock'
+  };
+
   const puzzle = map[scrambleType];
+  let scramble = '';
   if (puzzle) {
-    scrambleDisplay.textContent = cubejs.scramble(puzzle);
+    try {
+      scramble = cubejs.scramble(puzzle);
+    } catch (e) {
+      scramble = 'Scramble not available';
+    }
   } else {
-    scrambleDisplay.textContent = '';
+    scramble = 'Scramble not available';
   }
+  scrambleDisplay.textContent = scramble;
 }
 
 export function startInspection() {


### PR DESCRIPTION
## Summary
- support cubejs scrambles for 5x5–7x7 and side events
- update readme wording about cubejs
- record summary in `AGENTS.md`

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576e3139dc8322b7d8c46da19ce48e