### PR TITLE
Add time mode selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,7 @@ This file records a summary of repository changes and a short description of eac
 ### PR: Support more scrambles
 - Extended `generateScramble()` in `timer.js` to cover 5x5–7x7 and non-cube puzzles.
 - Updated the readme to note cubejs provides scrambles for common WCA events.
+
+### PR: Add time mode selector
+- Replaced the one-hour checkbox with a dropdown to choose 10 minutes, 1 hour, or infinite time.
+- Updated `formatTime()` in `timer.js` to respect the selected limit.

--- a/index.php
+++ b/index.php
@@ -35,7 +35,11 @@
   <option value="clock">Clock</option>
 
 </select>
-<label><input type="checkbox" id="oneHour"> 1小時模式</label>
+<select id="timeMode">
+  <option value="600000">10分鐘</option>
+  <option value="3600000">1小時</option>
+  <option value="Infinity">自由</option>
+</select>
 </div>
 <script src="https://unpkg.com/cubejs/lib/cube.min.js"></script>
 <script type="module">

--- a/timer.js
+++ b/timer.js
@@ -5,7 +5,7 @@ const statusDisplay = document.getElementById('status');
 const scrambleDisplay = document.getElementById('scramble');
 const hideTimeCheck = document.getElementById('hideTime');
 const scrambleTypeSelect = document.getElementById('scrambleType');
-const oneHourCheck = document.getElementById('oneHour');
+const timeModeSelect = document.getElementById('timeMode');
 
 let timerInterval = null;
 let startTime = 0;
@@ -24,7 +24,17 @@ function pad(n, width) {
 }
 
 export function formatTime(ms) {
-  const max = oneHourCheck.checked ? 3600000 : 600000;
+  let max;
+  switch (timeModeSelect.value) {
+    case '600000':
+      max = 600000;
+      break;
+    case '3600000':
+      max = 3600000;
+      break;
+    default:
+      max = Infinity;
+  }
   if (ms > max) ms = max;
   const m = Math.floor(ms / 60000);
   const s = Math.floor((ms % 60000) / 1000);


### PR DESCRIPTION
## Summary
- remove 1 hour mode checkbox
- add time mode select with 10 minutes, 1 hour or unlimited options
- update timer logic to respect the selected mode
- record new change in AGENTS log

## Testing
- `node --check timer.js`
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857701a1e1483229dbe05f6066c40e6