### PR TITLE
Improve inspection countdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,8 @@ This file records a summary of repository changes and a short description of eac
 ### PR: Add time mode selector
 - Replaced the one-hour checkbox with a dropdown to choose 10 minutes, 1 hour, or infinite time.
 - Updated `formatTime()` in `timer.js` to respect the selected limit.
+
+### PR: Improve inspection countdown
+- Display the remaining time during inspection, updating every 100 ms.
+- Highlight 8–12 seconds in yellow and 12–15 seconds in red.
+- Show “DNF” after 17 seconds and reset the countdown whenever a new scramble is generated.

--- a/timer.js
+++ b/timer.js
@@ -76,17 +76,23 @@ export function startInspection() {
   inspectionStart = Date.now();
   statusDisplay.textContent = '';
   statusDisplay.className = '';
+  clearInterval(inspectionInterval);
   inspectionInterval = setInterval(() => {
-    const t = (Date.now() - inspectionStart) / 1000;
-    if (t >= 8 && t < 12) {
-      statusDisplay.textContent = '8 Seconds';
-      statusDisplay.className = 'big-yellow';
-    } else if (t >= 12 && t < 15) {
-      statusDisplay.textContent = '12 Seconds';
+    const elapsed = (Date.now() - inspectionStart) / 1000;
+    const remaining = 15 - elapsed;
+
+    if (elapsed >= 17) {
+      statusDisplay.textContent = 'DNF';
       statusDisplay.className = 'big-red';
-    } else if (t >= 15) {
-      statusDisplay.textContent = '\u5df2\u8d85\u6642';
-      statusDisplay.className = 'big-red';
+    } else {
+      statusDisplay.textContent = remaining.toFixed(1);
+      if (elapsed >= 12) {
+        statusDisplay.className = 'big-red';
+      } else if (elapsed >= 8) {
+        statusDisplay.className = 'big-yellow';
+      } else {
+        statusDisplay.className = '';
+      }
     }
   }, 100);
 }
@@ -165,5 +171,8 @@ document.body.addEventListener('keyup', e => {
   }
 });
 
-scrambleTypeSelect.addEventListener('change', generateScramble);
+scrambleTypeSelect.addEventListener('change', () => {
+  generateScramble();
+  startInspection();
+});
 


### PR DESCRIPTION
## Summary
- show remaining inspection time instead of fixed labels
- highlight 8–12 seconds in yellow, 12–15 seconds in red
- show DNF after 17 seconds
- reset inspection countdown on scramble change

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685772a7cfd08322af039b3beec36591