### PR TITLE
Add inspection timing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,8 @@ This file records a summary of repository changes and a short description of eac
 - Display the remaining time during inspection, updating every 100 ms.
 - Highlight 8–12 seconds in yellow and 12–15 seconds in red.
 - Show “DNF” after 17 seconds and reset the countdown whenever a new scramble is generated.
+
+### PR: Test inspection timing
+- Confirmed `startInspection()` resets `inspectionStart` for every solve.
+- Updated `computePenalty()` to return the applied penalty and added `getPenalty()` for tests.
+- Added Node-based tests ensuring penalties use the new `inspectionStart` and trigger at the 15/17 s marks.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex_test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/test/timer.test.mjs
+++ b/test/timer.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Minimal DOM stubs
+global.document = {
+  elements: {},
+  getElementById(id) {
+    if (!this.elements[id]) {
+      this.elements[id] = { textContent: '', className: '', value: '', checked: false, addEventListener() {} };
+    }
+    return this.elements[id];
+  },
+  body: { addEventListener() {} }
+};
+
+const timer = await import('../timer.js');
+
+function withFakeNow(start, cb) {
+  const original = Date.now;
+  let now = start;
+  Date.now = () => now;
+  try {
+    cb(v => now = v);
+  } finally {
+    Date.now = original;
+  }
+}
+
+test('inspectionStart resets each solve', () => {
+  withFakeNow(0, setNow => {
+    timer.startInspection();
+    setNow(16000);
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '+2');
+    timer.stopInspection();
+
+    timer.startInspection();
+    setNow(30000); // 14s after new start
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '');
+    timer.stopInspection();
+  });
+});
+
+test('computePenalty respects DNF threshold', () => {
+  withFakeNow(0, setNow => {
+    timer.startInspection();
+    setNow(18000);
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), 'DNF');
+    timer.stopInspection();
+
+    timer.startInspection();
+    setNow(34000); // 16s after new start
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '+2');
+    timer.stopInspection();
+  });
+});

--- a/timer.js
+++ b/timer.js
@@ -134,6 +134,12 @@ export function computePenalty() {
   const t = (Date.now() - inspectionStart) / 1000;
   if (t >= 17) penalty = 'DNF';
   else if (t >= 15) penalty = '+2';
+  else penalty = '';
+  return penalty;
+}
+
+export function getPenalty() {
+  return penalty;
 }
 
 document.body.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- expose penalty for tests and return it
- add node-based tests to ensure inspection timer resets each solve
- create package.json for Node test runner
- document new PR in AGENTS log

## Testing
- `node --test test/timer.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_685775fcfd0c8322bec372f4c656624c