### PR TITLE
Fix countdown flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,22 @@ This file records a summary of repository changes and a short description of eac
 - Display the remaining time during inspection, updating every 100 ms.
 - Highlight 8–12 seconds in yellow and 12–15 seconds in red.
 - Show “DNF” after 17 seconds and reset the countdown whenever a new scramble is generated.
+
+### PR: Test inspection timing
+- Confirmed `startInspection()` resets `inspectionStart` for every solve.
+- Updated `computePenalty()` to return the applied penalty and added `getPenalty()` for tests.
+- Added Node-based tests ensuring penalties use the new `inspectionStart` and trigger at the 15/17 s marks.
+
+### PR: Add manual start and countdown display
+- Introduced a separate countdown element to avoid overlapping the status square.
+- Countdown uses whole seconds with red/yellow highlights.
+- Scrambles and inspection start only after pressing the spacebar, with a prompt shown between solves.
+
+### PR: Fix countdown flow
+- Hide scrambles until the spacebar is pressed
+- Countdown shows 15 down to 0 in integers
+- Clear status and scramble when prompting to start
+
+### PR: Add countdown placeholder
+- Display "請按一下空白鍵開始" in `#countdown` on page load
+- Center countdown text vertically with `line-height`

--- a/index.php
+++ b/index.php
@@ -8,6 +8,7 @@
   #timer {font-size:60px; margin-top:40px;}
   #scramble {margin-top:20px; font-size:20px; word-wrap:break-word; width:90%; margin-left:auto; margin-right:auto;}
   #status {margin-top:10px; height:30px;}
+  #countdown {margin-top:5px; height:30px; line-height:30px;}
   .yellow {color:yellow;}
   .green {color:#0f0;}
   .big-yellow {color:yellow; font-size:40px;}
@@ -18,6 +19,7 @@
 <h1>Cubing Timer</h1>
 <div id="timer">00:00.000</div>
 <div id="status"></div>
+<div id="countdown">請按一下空白鍵開始</div>
 <div id="scramble"></div>
 <div style="margin-top:20px;">
 <label><input type="checkbox" id="hideTime"> 隱藏計時</label>
@@ -43,9 +45,7 @@
 </div>
 <script src="https://unpkg.com/cubejs/lib/cube.min.js"></script>
 <script type="module">
-import {generateScramble, startInspection} from "./timer.js";
-generateScramble();
-startInspection();
+import './timer.js';
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex_test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/test/timer.test.mjs
+++ b/test/timer.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Minimal DOM stubs
+global.document = {
+  elements: {},
+  getElementById(id) {
+    if (!this.elements[id]) {
+      this.elements[id] = { textContent: '', className: '', value: '', checked: false, addEventListener() {} };
+    }
+    return this.elements[id];
+  },
+  body: { addEventListener() {} }
+};
+
+const timer = await import('../timer.js');
+
+function withFakeNow(start, cb) {
+  const original = Date.now;
+  let now = start;
+  Date.now = () => now;
+  try {
+    cb(v => now = v);
+  } finally {
+    Date.now = original;
+  }
+}
+
+test('inspectionStart resets each solve', () => {
+  withFakeNow(0, setNow => {
+    timer.startInspection();
+    setNow(16000);
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '+2');
+    timer.stopInspection();
+
+    timer.startInspection();
+    setNow(30000); // 14s after new start
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '');
+    timer.stopInspection();
+  });
+});
+
+test('computePenalty respects DNF threshold', () => {
+  withFakeNow(0, setNow => {
+    timer.startInspection();
+    setNow(18000);
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), 'DNF');
+    timer.stopInspection();
+
+    timer.startInspection();
+    setNow(34000); // 16s after new start
+    timer.computePenalty();
+    assert.equal(timer.getPenalty(), '+2');
+    timer.stopInspection();
+  });
+});


### PR DESCRIPTION
## Summary
- clear scramble and status when prompting for the next solve
- display countdown as integers from 15 down to 0
- hide scrambles until spacebar starts inspection
- show start prompt on page load

## Testing
- `node --test test/timer.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685775fcfd0c8322bec372f4c656624c